### PR TITLE
Nk fix camera max devices

### DIFF
--- a/TikTokTrainer/Camera/CameraModel.swift
+++ b/TikTokTrainer/Camera/CameraModel.swift
@@ -513,6 +513,9 @@ extension CameraModel: MTKViewDelegate {
             return
         }
         
+        // TODO: fix screen size scaling on max devices (temporary fix)
+        view.drawableSize = ciImage.extent.size
+        
         // make sure frame is centered on screen
         let heightOfciImage = ciImage.extent.height
         let heightOfDrawable = view.drawableSize.height


### PR DESCRIPTION
Temporarily fixes the camera preview size on max devices, but the image is still stretched.