### PR TITLE
Remove CI/CD build step and reorder lint and tests

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,25 +5,6 @@ agent:
     type: a1-standard-4
     os_image: macos-xcode12
 blocks:
-  - name: Fastlane Tests
-    task:
-      env_vars:
-        - name: LANG
-          value: en_US.UTF-8
-      prologue:
-        commands:
-          - checkout develop
-          - cache restore
-          - gem install bundler -v '2.2.6'
-          - bundle install --path vendor/bundle
-          - cache store
-      jobs:
-        - name: bundle exec fastlane test
-          commands:
-            - bundle exec xcversion select 12.3
-            - bundle exec fastlane test
-      secrets:
-        - name: fastlane-env
   - name: Fastlane SwiftLint
     task:
       env_vars:
@@ -43,28 +24,25 @@ blocks:
             - bundle exec fastlane lint_all
       secrets:
         - name: fastlane-env
-  - name: Fastlane Build
+  - name: Fastlane Tests
     task:
       env_vars:
         - name: LANG
           value: en_US.UTF-8
       prologue:
         commands:
-          - checkout
+          - checkout develop
           - cache restore
           - gem install bundler -v '2.2.6'
           - bundle install --path vendor/bundle
           - cache store
       jobs:
-        - name: bundle exec fastlane build
+        - name: bundle exec fastlane test
           commands:
-            - chmod 0600 ~/.keys/*
-            - ssh-add ~/.keys/*
             - bundle exec xcversion select 12.3
-            - bundle exec fastlane build
+            - bundle exec fastlane test
       secrets:
         - name: fastlane-env
-        - name: ios-cert-repo
 promotions:
   - name: TestFlight deploy
     pipeline_file: beta-deploy.yml


### PR DESCRIPTION
The app will already try to build during the tests and the promotion step if it is promoted. This should reduce the CI/CD time by 2 minutes. Also moved swiftlint to the first step which should cause the CI/CD to fail faster if there are lint issues. This should also reduce build time when lint issues exist.