### PR TITLE
Fix camera never appearing on allowing camera permissions

### DIFF
--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -788,7 +788,7 @@
 				LastUpgradeCheck = 1100;
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
-			compatibilityVersion = "Xcode 9.3";
+			compatibilityVersion = "Xcode 10.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/TikTokTrainer/UI/CameraView.swift
+++ b/TikTokTrainer/UI/CameraView.swift
@@ -375,7 +375,7 @@ struct CameraView: View {
         .sheet(isPresented: $isVideoPickerOpen) {
             imagePicker
         }
-        .onAppear(perform: camera.checkPermissionsAndSetup)
+        .onAppear(perform: { camera.checkPermissionsAndSetup(permissions) })
     }
 }
 


### PR DESCRIPTION
Fix the app never fully starting on first load after clicking allow camera. There is still an issue of it taking ~10 seconds for the camera to appear but it seems this is due to the first Vision call causing some background metal process to fail twice before resetting a cache. 