### PR TITLE
Add performance test for PoseNet processing

### DIFF
--- a/TikTokTrainer.xcodeproj/project.pbxproj
+++ b/TikTokTrainer.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0E12CFE725D7AF02003880B7 /* PoseNetResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E12CFE625D7AF02003880B7 /* PoseNetResult.swift */; };
 		0E12CFFA25D86181003880B7 /* TestImage.PNG in Resources */ = {isa = PBXBuildFile; fileRef = 0E12CFF925D86181003880B7 /* TestImage.PNG */; };
 		0E1BDB8B25D5940800F6CFA8 /* PoseNetProcesser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1BDB8A25D5940800F6CFA8 /* PoseNetProcesser.swift */; };
+		0E23B85625E6B89B00008FFD /* TestDance.mov in Resources */ = {isa = PBXBuildFile; fileRef = 0E23B85525E6B89B00008FFD /* TestDance.mov */; };
 		5F12871225C49FD50027DC22 /* CameraModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F12871125C49FD50027DC22 /* CameraModel.swift */; };
 		5F1BBF2725DEBC51007CBD42 /* VideoPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F1BBF2625DEBC51007CBD42 /* VideoPreview.swift */; };
 		5F573A5C25E01155000F6719 /* moon.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 5F573A5B25E01155000F6719 /* moon.mp4 */; };
@@ -67,6 +68,7 @@
 		0E12CFE625D7AF02003880B7 /* PoseNetResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseNetResult.swift; sourceTree = "<group>"; };
 		0E12CFF925D86181003880B7 /* TestImage.PNG */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TestImage.PNG; sourceTree = "<group>"; };
 		0E1BDB8A25D5940800F6CFA8 /* PoseNetProcesser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoseNetProcesser.swift; sourceTree = "<group>"; };
+		0E23B85525E6B89B00008FFD /* TestDance.mov */ = {isa = PBXFileReference; lastKnownFileType = video.quicktime; path = TestDance.mov; sourceTree = "<group>"; };
 		3E232AF959113C366B24B77F /* Pods_TikTokTrainerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TikTokTrainerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		543B1B8C80547A2E4E47DF78 /* Pods-TikTokTrainer-TikTokTrainerUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TikTokTrainer-TikTokTrainerUITests.debug.xcconfig"; path = "Target Support Files/Pods-TikTokTrainer-TikTokTrainerUITests/Pods-TikTokTrainer-TikTokTrainerUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		5E17AF5505DAB7F3B67FF5E3 /* Pods-TikTokTrainer-TikTokTrainerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TikTokTrainer-TikTokTrainerUITests.release.xcconfig"; path = "Target Support Files/Pods-TikTokTrainer-TikTokTrainerUITests/Pods-TikTokTrainer-TikTokTrainerUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 		0E02D14725AFA56900004B2A = {
 			isa = PBXGroup;
 			children = (
+				0E23B85525E6B89B00008FFD /* TestDance.mov */,
 				BCB9D38B25E4423200C7DC9B /* preRecordedVid.mp4 */,
 				BCB9D38625E441E200C7DC9B /* recordedVid.mp4 */,
 				5F573A5B25E01155000F6719 /* moon.mp4 */,
@@ -348,6 +351,7 @@
 				BCB9D38C25E4423200C7DC9B /* preRecordedVid.mp4 in Resources */,
 				BCB9D38725E441E200C7DC9B /* recordedVid.mp4 in Resources */,
 				0E12CFFA25D86181003880B7 /* TestImage.PNG in Resources */,
+				0E23B85625E6B89B00008FFD /* TestDance.mov in Resources */,
 				0E02D15B25AFA56A00004B2A /* Preview Assets.xcassets in Resources */,
 				0E02D15825AFA56A00004B2A /* Assets.xcassets in Resources */,
 			);

--- a/TikTokTrainer.xcodeproj/xcshareddata/xcbaselines/0E02D16025AFA56A00004B2A.xcbaseline/0FB50D46-F4F5-4598-B9EE-2AE1C0DB9604.plist
+++ b/TikTokTrainer.xcodeproj/xcshareddata/xcbaselines/0E02D16025AFA56A00004B2A.xcbaseline/0FB50D46-F4F5-4598-B9EE-2AE1C0DB9604.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>TikTokTrainerTests</key>
+		<dict>
+			<key>testPoseNetProcessorPerformance()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>34.876</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+				<key>com.apple.dt.XCTMetric_Clock.time.monotonic</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>33.798</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/TikTokTrainer.xcodeproj/xcshareddata/xcbaselines/0E02D16025AFA56A00004B2A.xcbaseline/Info.plist
+++ b/TikTokTrainer.xcodeproj/xcshareddata/xcbaselines/0E02D16025AFA56A00004B2A.xcbaseline/Info.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>0FB50D46-F4F5-4598-B9EE-2AE1C0DB9604</key>
+		<dict>
+			<key>targetArchitecture</key>
+			<string>arm64e</string>
+			<key>targetDevice</key>
+			<dict>
+				<key>modelCode</key>
+				<string>iPhone13,4</string>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.iphoneos</string>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/TikTokTrainer.xcodeproj/xcshareddata/xcschemes/TikTokTrainer.xcscheme
+++ b/TikTokTrainer.xcodeproj/xcshareddata/xcschemes/TikTokTrainer.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0E02D14F25AFA56900004B2A"
+               BuildableName = "TikTokTrainer.app"
+               BlueprintName = "TikTokTrainer"
+               ReferencedContainer = "container:TikTokTrainer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0E02D16025AFA56A00004B2A"
+               BuildableName = "TikTokTrainerTests.xctest"
+               BlueprintName = "TikTokTrainerTests"
+               ReferencedContainer = "container:TikTokTrainer.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0E02D16B25AFA56A00004B2A"
+               BuildableName = "TikTokTrainerUITests.xctest"
+               BlueprintName = "TikTokTrainerUITests"
+               ReferencedContainer = "container:TikTokTrainer.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0E02D14F25AFA56900004B2A"
+            BuildableName = "TikTokTrainer.app"
+            BlueprintName = "TikTokTrainer"
+            ReferencedContainer = "container:TikTokTrainer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0E02D14F25AFA56900004B2A"
+            BuildableName = "TikTokTrainer.app"
+            BlueprintName = "TikTokTrainer"
+            ReferencedContainer = "container:TikTokTrainer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/TikTokTrainerTests/TikTokTrainerTests.swift
+++ b/TikTokTrainerTests/TikTokTrainerTests.swift
@@ -10,14 +10,15 @@ import XCTest
 @testable import TikTokTrainer
 
 class TikTokTrainerTests: XCTestCase {
-    func testPoseNetProcessorPerformance() {
-        let url = Bundle.main.url(forResource: "TestDance", withExtension: "mov")!
-        let measureOptions = XCTMeasureOptions()
-        measureOptions.iterationCount = 2
-        self.measure(options: measureOptions) {
-            _ = PoseNetProcessor.run(url: url)
-
-            XCTAssert(waitForPromises(timeout: 200))
-        }
-    }
+//    This function takes a very long time to run on CI/CD so it is commented so you can run it locally
+//    func testPoseNetProcessorPerformance() {
+//        let url = Bundle.main.url(forResource: "TestDance", withExtension: "mov")!
+//        let measureOptions = XCTMeasureOptions()
+//        measureOptions.iterationCount = 2
+//        self.measure(options: measureOptions) {
+//            _ = PoseNetProcessor.run(url: url)
+//
+//            XCTAssert(waitForPromises(timeout: 200))
+//        }
+//    }
 }

--- a/TikTokTrainerTests/TikTokTrainerTests.swift
+++ b/TikTokTrainerTests/TikTokTrainerTests.swift
@@ -6,28 +6,18 @@
 //
 
 import XCTest
+@testable import Promises
 @testable import TikTokTrainer
 
 class TikTokTrainerTests: XCTestCase {
+    func testPoseNetProcessorPerformance() {
+        let url = Bundle.main.url(forResource: "TestDance", withExtension: "mov")!
+        let measureOptions = XCTMeasureOptions()
+        measureOptions.iterationCount = 2
+        self.measure(options: measureOptions) {
+            _ = PoseNetProcessor.run(url: url)
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+            XCTAssert(waitForPromises(timeout: 200))
         }
     }
-
 }


### PR DESCRIPTION
Add a performance test to track regressions or improvements in PoseNet processing. The test is commented out so it does not run on CI/CD but still runs locally. It would take >10 minutes to run on the pipeline.