### PR TITLE
Store URL for previous saved videos

### DIFF
--- a/TikTokTrainer/Camera/CameraModel.swift
+++ b/TikTokTrainer/Camera/CameraModel.swift
@@ -31,6 +31,7 @@ class CameraModel: NSObject,
     // camera feed
     let cameraSession = AVCaptureSession()
     var outputURL: URL!
+    var previousSavedURL: URL = URL(string: "placeholder")!
     var imageBounds: CGSize!
     var frontCameraDevice: AVCaptureDevice?
     var backCameraDevice: AVCaptureDevice?
@@ -224,6 +225,7 @@ class CameraModel: NSObject,
                 PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: self.outputURL)
             }) { saved, error in
                 if saved {
+                    self.previousSavedURL = self.outputURL
                     self.setup()
                         if !isEarly {
                             DispatchQueue.main.async {

--- a/TikTokTrainer/UI/CameraView.swift
+++ b/TikTokTrainer/UI/CameraView.swift
@@ -52,11 +52,11 @@ struct CameraView: View {
         // Run PoseNetProcessor on two videos and feed result to scoring function
         all(
             PoseNetProcessor.run(url: self.uploadedVideoURL),
-            PoseNetProcessor.run(url: camera.outputURL)
+            PoseNetProcessor.run(url: self.camera.previousSavedURL)
         ).then { movieOne, movieTwo in
             return ScoringFunction(preRecordedVid: movieOne, recordedVid: movieTwo).computeScore()
         }.then{ score in
-            print(score)
+            print("Video score: \(score)")
             self.isLoading = false
         }.catch { error in
             print("Error: \(error)")


### PR DESCRIPTION
The URL for recorded videos was being overwritten before the scoring function could access it.