### PR TITLE
BG color for Tutorial and History pages are not set correctly on when device is on dark mode

### DIFF
--- a/TikTokTrainer/UI/ContentView.swift
+++ b/TikTokTrainer/UI/ContentView.swift
@@ -51,7 +51,7 @@ struct ContentView: View {
             }
         }
         .accentColor(Color.red)
-        .background(Color.black)
+        .background(selectedTab == 1 ? Color.black : Color.white)
         .onAppear(perform: resetTabBarColor)
         .id(selectedTab)
     }


### PR DESCRIPTION
Closes #98 