### PR TITLE
Link mistakes and timestamps of mistakes to StoredResult object and integrate with ResultsView, HistoryView, and RowResult

### DIFF
--- a/TikTokTrainer/Data/ProcessedVideoModel.xcdatamodeld/ProcessedVideoModel.xcdatamodel/contents
+++ b/TikTokTrainer/Data/ProcessedVideoModel.xcdatamodeld/ProcessedVideoModel.xcdatamodel/contents
@@ -1,32 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="19H2" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="PoseNetData" representedClassName=".PoseNetData" parentEntity="StoredVideo" syncable="YES" codeGenerationType="class">
-        <attribute name="startTime" attributeType="Integer 64" usesScalarValueType="YES"/>
-        <relationship name="poses" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PosePoint" inverseName="pose_for" inverseEntity="PosePoint"/>
-        <relationship name="video_data_for" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StoredVideo" inverseName="pose_data" inverseEntity="StoredVideo"/>
-    </entity>
-    <entity name="PosePoint" representedClassName=".PosePoint" parentEntity="PoseNetData" syncable="YES" codeGenerationType="class">
-        <attribute name="poseName" attributeType="String"/>
-        <attribute name="poseNormalizedX" attributeType="Decimal" defaultValueString="0.0"/>
-        <attribute name="poseNormalizedY" attributeType="Decimal" defaultValueString="0.0"/>
-        <relationship name="pose_for" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PoseNetData" inverseName="poses" inverseEntity="PoseNetData"/>
-    </entity>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="StoredResult" representedClassName=".StoredResult" syncable="YES" codeGenerationType="class">
-        <attribute name="duration" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="duration" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="mistakes" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="recording" attributeType="URI"/>
         <attribute name="score" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="timestamp" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="tutorial" attributeType="URI"/>
     </entity>
-    <entity name="StoredVideo" representedClassName=".StoredVideo" syncable="YES" codeGenerationType="class">
-        <attribute name="location" attributeType="URI"/>
-        <attribute name="storedDateTime" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="pose_data" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="PoseNetData" inverseName="video_data_for" inverseEntity="PoseNetData"/>
-    </entity>
     <elements>
-        <element name="PoseNetData" positionX="-4.55859375" positionY="125.453125" width="128" height="88"/>
-        <element name="PosePoint" positionX="227.2265625" positionY="130.16796875" width="128" height="103"/>
-        <element name="StoredResult" positionX="45" positionY="153" width="128" height="118"/>
-        <element name="StoredVideo" positionX="-161.421875" positionY="83.171875" width="128" height="88"/>
+        <element name="StoredResult" positionX="45" positionY="153" width="128" height="119"/>
     </elements>
 </model>

--- a/TikTokTrainer/UI/CameraTab/CameraPlaybackView.swift
+++ b/TikTokTrainer/UI/CameraTab/CameraPlaybackView.swift
@@ -19,7 +19,7 @@ struct CameraPlaybackView: View {
     @State var dimmerOpacity = 0.8
     @State var showLoadingScreen: Bool = false
     @State var score: Double = Double.nan
-    @State var mistakes: [CGFloat] = []
+    @State var mistakes: Int = 0
     @State var resultOutcome: ResultsOutcome?
 
     var animatableData: Double {
@@ -41,12 +41,6 @@ struct CameraPlaybackView: View {
 
     func submit() {
         self.showLoadingScreen = true
-
-        let dbVideo = StoredVideo(context: managedObjectContext)
-        dbVideo.location = self.camera.previousSavedURL
-        dbVideo.storedDateTime = Date.init()
-        DataController.shared.save()
-        // Run PoseNetProcessor on two videos and feed result to scoring function
         all(
             PoseNetProcessor.run(url: self.selectedVideo!.videoURL),
             PoseNetProcessor.run(url: self.camera.previousSavedURL)
@@ -56,7 +50,7 @@ struct CameraPlaybackView: View {
             self.showLoadingScreen = false
             self.score = score.isNaN ? 0 : Double(score)
             self.score = (self.score * 10000).rounded() / 100
-            self.mistakes = mistakes
+            self.mistakes = mistakes.count
             self.showResultsScreen = true
         }.catch { error in
             print("Error scoring videos: \(error)")

--- a/TikTokTrainer/UI/CameraTab/ResultsView.swift
+++ b/TikTokTrainer/UI/CameraTab/ResultsView.swift
@@ -23,7 +23,7 @@ struct ResultsView: View {
     @Binding var resultOutcome: ResultsOutcome?
 
     var score: Double
-    var mistakes: [CGFloat]
+    var mistakes: Int
     var duration: Double
     var recording: URL
     var tutorial: URL
@@ -39,6 +39,7 @@ struct ResultsView: View {
         let dbResult = StoredResult(context: managedObjectContext)
         dbResult.timestamp = Date.init()
         dbResult.score = score.isNaN ? 0 : Double(score)
+        dbResult.mistakes = Int64(mistakes)
         dbResult.recording = recording.absoluteURL
         dbResult.tutorial = tutorial.absoluteURL
         dbResult.duration = Int64(round(duration))
@@ -113,7 +114,7 @@ struct ResultsView: View {
                         Text("Score: \(String(format: "%.2f", score))%")
                             .padding(.bottom, 10)
                             .foregroundColor(Color.black)
-                        Text("Mistakes: \(mistakes.count)")
+                        Text("Mistakes: \(mistakes)")
                             .padding(.bottom, 10)
                             .foregroundColor(Color.black)
                         Text("Duration: \(Int(round(duration))) seconds")

--- a/TikTokTrainer/UI/HistoryDetailView.swift
+++ b/TikTokTrainer/UI/HistoryDetailView.swift
@@ -59,7 +59,7 @@ struct HistoryDetailView: View {
                         Text("Score: \(String(format: "%.2f", result.score))%")
                         .padding(.bottom, 10)
                         .foregroundColor(Color.black)
-                    Text("Mistakes: MISTAKES")
+                    Text("Mistakes: \(result.mistakes)")
                         .padding(.bottom, 10)
                         .foregroundColor(Color.black)
                         Text("Duration: \(result.duration) seconds")

--- a/TikTokTrainer/UI/ResultRow.swift
+++ b/TikTokTrainer/UI/ResultRow.swift
@@ -29,7 +29,7 @@ struct ResultRow: View {
                     .foregroundColor(Color.black)
                 Text("Duration: \(result.duration) seconds")
                     .foregroundColor(Color.black)
-                Text("Mistakes: MISTAKES")
+                Text("Mistakes: \(result.mistakes)")
                     .foregroundColor(Color.black)
             }
         }


### PR DESCRIPTION
- Decided against linking mistakes timestamps to everything as it would clog up most of our screens and is way too much work considering the final report is due in a week.