### PR TITLE
Change pose processing to every other frame

### DIFF
--- a/TikTokTrainer/Data/PoseNetProcessor.swift
+++ b/TikTokTrainer/Data/PoseNetProcessor.swift
@@ -37,6 +37,8 @@ struct PoseNetProcessor: PoseNetProcessorProtocol {
     static func run(url: URL) -> Promise<ProcessedVideo> {
         let promise = Promise<ProcessedVideo> { fulfill, reject in
             var processedVideo = ProcessedVideo(url: url)
+            let videoProcessingOptions = VNVideoProcessor.RequestProcessingOptions()
+            videoProcessingOptions.cadence = VNVideoProcessor.FrameRateCadence(2)
             let videoProcessor = VNVideoProcessor(url: url)
             let humanRequest = VNDetectHumanBodyPoseRequest(completionHandler: { request, err in
                 /// Error on the request should fail the whole processing because this may be the sign of a bigger issue.
@@ -59,7 +61,7 @@ struct PoseNetProcessor: PoseNetProcessorProtocol {
 
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
-                    try videoProcessor.addRequest(humanRequest, processingOptions: VNVideoProcessor.RequestProcessingOptions())
+                    try videoProcessor.addRequest(humanRequest, processingOptions: videoProcessingOptions)
                     try videoProcessor.analyze(CMTimeRange(start: CMTime.zero, end: CMTime.indefinite))
                 } catch {
                     print("Error processing PoseNet for Video with url \(url).\n Error: \(error)")


### PR DESCRIPTION
We don't need every single frame when comparing movements. This changes the frame rate cadence to 2 meaning every other frame will be considered.